### PR TITLE
update github action version

### DIFF
--- a/.github/workflows/hugo.yml
+++ b/.github/workflows/hugo.yml
@@ -40,12 +40,12 @@ jobs:
       - name: Install Dart Sass Embedded
         run: sudo snap install dart-sass-embedded
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           submodules: recursive
       - name: Setup Pages
         id: pages
-        uses: actions/configure-pages@v3
+        uses: actions/configure-pages@v5
       - name: Install Node.js dependencies
         run: "[[ -f package-lock.json || -f npm-shrinkwrap.json ]] && npm ci || true"
       - name: Build with Hugo
@@ -58,7 +58,7 @@ jobs:
             --minify \
             --baseURL "${{ steps.pages.outputs.base_url }}/"
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v1
+        uses: actions/upload-pages-artifact@v3
         with:
           path: ./public
 
@@ -72,4 +72,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v2
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -39,12 +39,12 @@ jobs:
       - name: Install Dart Sass Embedded
         run: sudo snap install dart-sass-embedded
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           submodules: recursive
       - name: Setup Pages
         id: pages
-        uses: actions/configure-pages@v3
+        uses: actions/configure-pages@v5
       - name: Install Node.js dependencies
         run: "[[ -f package-lock.json || -f npm-shrinkwrap.json ]] && npm ci || true"
       - name: Build with Hugo
@@ -57,7 +57,7 @@ jobs:
             --minify \
             --baseURL "${{ steps.pages.outputs.base_url }}/"
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v1
+        uses: actions/upload-pages-artifact@v3
         with:
           path: ./public
 
@@ -71,5 +71,5 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v1
+        uses: actions/deploy-pages@v4
 

--- a/config.toml
+++ b/config.toml
@@ -299,7 +299,7 @@ pluralizelisttitles = false
     contact_form_ajax = false
 
     about_us = "<p>The ACM Special Interest Group on Software Engineering provides a forum for computing professionals from industry, government and academia to examine principles, practices, and new research results in software engineering.</p>"
-    copyright = "Copyright (c) 2020 - 2023, SIGSOFT; all rights reserved."
+    copyright = "Copyright (c) 2020 - 2025, SIGSOFT; all rights reserved."
 
     # Format dates with Go's time formatting
     date_format = "January 2, 2006"


### PR DESCRIPTION
The previous GitHub workflow contains deprecated actions, which result in building failures like https://github.com/acmsigsoft/acmsigsoft.github.io/actions/runs/13066284055.

The information of the deprecated actions can be found here: 
https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/ 

Now the actions are updated following suggestions here https://github.com/actions/starter-workflows/blob/main/pages/hugo.yml