### PR TITLE
new branch for awards overview

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -157,46 +157,54 @@ pluralizelisttitles = false
     parent     = "menu.features"
     post       = 2
 
+
+[[menu.main]]
+    name       = "SIGSOFT Awards Overview"
+    url        = "/awards/sigsoftAwards"
+    weight     = 1
+    parent     = "section.awards"
+
+
 [[menu.main]]
     name       = "Distinguished Service"
     url        = "/awards/distinguishedService"
-    weight     = 1
+    weight     = 2
     parent     = "section.awards"
 
 [[menu.main]]
     name       = "Outstanding Research"
     url        = "/awards/outstandingResearch"
-    weight     = 2
+    weight     = 3
     parent     = "section.awards"
 
 [[menu.main]]
     name       = "Influential Educator"
     url        = "/awards/influentialEducator"
-    weight     = 3
+    weight     = 4
     parent     = "section.awards"
 
 [[menu.main]]
     name       = "Impact Paper"
     url        = "/awards/impactPaper"
-    weight     = 4
+    weight     = 5
     parent     = "section.awards"
 
 [[menu.main]]
     name       = "Outstanding Doctoral Dissertation"
     url        = "/awards/dissertation"
-    weight     = 5
+    weight     = 6
     parent     = "section.awards"
 
 [[menu.main]]
     name       = "Early Career Researcher"
     url        = "/awards/earlyCareerResearcher"
-    weight     = 6
+    weight     = 7
     parent     = "section.awards"
 
 [[menu.main]]
     name       = "ACM SIGSOFT - SIGBED Frank Anger Memorial"
     url        = "/awards/anger"
-    weight     = 7
+    weight     = 8
     parent     = "section.awards"
 
 [[menu.main]]
@@ -235,7 +243,7 @@ pluralizelisttitles = false
     weight     = 6
 
 [[menu.main]]
-    name       = "Overview"
+    name       = "Activities Overview"
     weight     = 1
     parent     = "menu.programs_activities"
     url        = "/activities/overview"
@@ -281,7 +289,7 @@ pluralizelisttitles = false
     weight     = 2
     parent     = "menu.join"
 
-    
+
 
 # Top bar social links menu
 

--- a/content/awards/outstandingResearch.md
+++ b/content/awards/outstandingResearch.md
@@ -77,7 +77,7 @@ If you have questions about this award, please contact sigsoft-research-award (a
 - Lionel Briand, University of Ottawa, Canada and University of Luxembourg, Luxembourg
 - Katsuro Inoue, Nanzan University, Japan
 - Barbara Paech, Heidelberg University, Germany
-- David Shepherd, Louisiana State University, USA 
+- David Shepherd, Louisiana State University, USA
 - Paola Spoletini, Kennesaw State University, USA
 - Sebastian Uchitel, Universidad de Buenos Aires, Argentina
 - Thomas Zimmermann, Microsoft Research, United States (SIGSOFT chair, non-voting)
@@ -89,7 +89,7 @@ If you have questions about this award, please contact sigsoft-research-award (a
 - Paris Avgeriou, University of Groningen, Netherlands
 - Luciano Baresi, Politecnico di Milano, Italy
 - Daniela Damian, University of Victoria, Canada
-- Prem Devambu, UC Davis, United States 
+- Prem Devambu, UC Davis, United States
 - Zhenjiang Hu, Peking University, China
 - Robyn Lutz, Iowa State University, United States
 - Thomas Zimmermann, Microsoft Research, United States (SIGSOFT chair, non-voting)

--- a/content/awards/sigsoftAwards.md
+++ b/content/awards/sigsoftAwards.md
@@ -1,0 +1,6 @@
+---
+weight: 1
+bookFlatSection: true
+title: "SIGSOFT Awards Overview"
+aliases: "/awards/outstandingResearchAward.html"
+---


### PR DESCRIPTION
As suggested by @clegoues, we are going to create a separate page to host all information about award nomination, so that we next year we do not need to update the dates on seven pages again. 