### PR TITLE
Centralize common awards content.

### DIFF
--- a/content/awards/anger.md
+++ b/content/awards/anger.md
@@ -5,26 +5,16 @@ title: " ACM SIGSOFT - SIGBED Frank Anger Award "
 aliases: "/awards/angerAward.html"
 ---
 
-
 In honor of our late colleague and friend, Dr. Frank Anger, the ACM Special Interest Group on Software Engineering has joined together with the [ACM Special Interest Group on Embedded Systems](https://sigbed.org/) to present the Frank Anger Memorial Award. Dr. Frank Anger, an outstanding national leader in the field of software engineering, died in a tragic automobile accident on July 8, 2004. One of Frank's primary goals was supporting the crossover of ideas between research communities engaged in software. As an outstanding scientist and recognized national leader in computer science, he worked toward this goal until his untimely death.
 
 In the spirit of Frank's work and legacy, the Executive Committees of SIGBED and SIGSOFT, with support from the US National Science Foundation, have established a student travel award in his name. The award provides $2000 stipends for two students, one named by each SIG, to cover travel expenses to attend the flagship conference of the other SIG. The award is meant to improve the mutual awareness of the two research communities to the opportunities and challenges emerging in complementary research areas.
 
-If you have questions about this award, please contact sigsoft-angermemorial-award (at) acm (dot) org.
+The award provides a student member of SIGSOFT a stipend of up to $2000 to cover travel expenses to attend a flagship conference of SIGBED.  The SIGSOFT recipient will also be recognized in the awards plenary session at ICSE. 
 
-## Rules and Applications
+To be eligible for the award, a student must be a SIGSOFT member undertaing graduate rearch in a relevant field in an accredited college or university.
 
-The award provides a student member of SIGSOFT a stipend of up to $2000 to cover travel expenses to attend a flagship conference of SIGBED.
+Consult the [main SIGSOFT Awards page](https://www2.sigsoft.org/awards/) for key dates and a link to the submission portal. The same intent to nominate and full package deadlines apply to this award as the other SIGSOFT awards.  Note, however, that the nomination package is distinct.  A single PDF containing the nomination package should be sumitted through the portal, and should contain: 
 
-### Eligibility
-To qualify, the student:
-1. must be a member of SIGSOFT
-2. must be undertaking graduate research in a relevant field in an accredited college or university
-
-### The Application Process
-To submit a nomination for the award, please use the [awards nomination portal](https://sigsoft-awards.hotcrp.com/). Please note that:
-
-* An intent to nominate must be submitted in the nomination system by October 6, 2025 (First Monday in October). <!-- October 21, 2024 (third Monday in October).--> The intent submission is very lightweight and only requires: (1) full name and affiliation of the nominated student, (2) contact information of the nominator, and (3) some metadata. If no intent is received by the deadline, the nomination will be deemed late and not considered for this round of award selection.
 * A single PDF containing the nomination package must be submitted through the portal to complete the submission by October 20, 2025, 2024 (two weeks after the registration deadline). The PDF should contain the following:
   1. Full name and affiliation of the nominated student
   2. Membership number (ACM/SIGSOFT)
@@ -33,11 +23,8 @@ To submit a nomination for the award, please use the [awards nomination portal](
   5. A curriculum vitae or resume listing the student's publications
   6. A letter from the student's research advisor confirming that the student is in good standing and pursuing the research as described in the proposal. The letter must include the following sentence: "To the best of my knowledge, the candidate I am endorsing has not committed any action that violates the ACM Code of Ethics and ACM's Core Values.
 
-### Selection Process
 
-Recipients of the SIGSOFT Frank Anger Memorial Award will be selected by the selection committee from those who have applied. The selection committee shall have the option to decline to make an award in a given year, if no suitable nominations are presented. The SIGSOFT recipient will be recognized at an awards ceremony at the International Conference on Software Engineering (ICSE).
-
-This award is a unique opportunity to help promote cross-discipline research. All eligible applicants are encouraged to apply. If you have questions about this award, please contact sigsoft-dissertation-award (at) acm (dot) org.
+This award is a unique opportunity to help promote cross-discipline research. All eligible applicants are encouraged to apply.  If you have questions about this award, please contact sigsoft-angermemorial-award (at) acm (dot) org.
 
 ## Winners
 

--- a/content/awards/anger.md
+++ b/content/awards/anger.md
@@ -13,7 +13,7 @@ The award provides a student member of SIGSOFT a stipend of up to $2000 to cover
 
 To be eligible for the award, a student must be a SIGSOFT member undertaing graduate rearch in a relevant field in an accredited college or university.
 
-Consult the [main SIGSOFT Awards page](/awards/sigsoftAwards/) for key dates and a link to the submission portal. The same intent to nominate and full package deadlines apply to this award as the other SIGSOFT awards.  Note, however, that the nomination package is distinct.  A single PDF containing the nomination package should be sumitted through the portal, and should contain: 
+Consult the [main SIGSOFT Awards page](/awards/sigsoftAwards/) for key dates and a link to the submission portal. The same intent to nominate and full package deadlines apply to this award as the other SIGSOFT awards.  Note, however, that the nomination package is distinct.  A single PDF containing the nomination package should be submitted through the portal, and should contain: 
   1. Full name and affiliation of the nominated student
   2. Membership number (ACM/SIGSOFT)
   3. A synopsis of an original research proposal that the student is pursuing (2 page limit)

--- a/content/awards/anger.md
+++ b/content/awards/anger.md
@@ -11,7 +11,7 @@ In the spirit of Frank's work and legacy, the Executive Committees of SIGBED and
 
 The award provides a student member of SIGSOFT a stipend of up to $2000 to cover travel expenses to attend a flagship conference of SIGBED.  The SIGSOFT recipient will also be recognized in the awards plenary session at ICSE. 
 
-To be eligible for the award, a student must be a SIGSOFT member undertaing graduate rearch in a relevant field in an accredited college or university.
+To be eligible for the award, a student must be a SIGSOFT member undertaking graduate research in a relevant field in an accredited college or university.
 
 Consult the [main SIGSOFT Awards page](/awards/sigsoftAwards/) for key dates and a link to the submission portal. The same intent to nominate and full package deadlines apply to this award as the other SIGSOFT awards.  Note, however, that the nomination package is distinct.  A single PDF containing the nomination package should be submitted through the portal, and should contain: 
   1. Full name and affiliation of the nominated student

--- a/content/awards/anger.md
+++ b/content/awards/anger.md
@@ -13,7 +13,7 @@ The award provides a student member of SIGSOFT a stipend of up to $2000 to cover
 
 To be eligible for the award, a student must be a SIGSOFT member undertaing graduate rearch in a relevant field in an accredited college or university.
 
-Consult the [main SIGSOFT Awards page](https://www2.sigsoft.org/awards/) for key dates and a link to the submission portal. The same intent to nominate and full package deadlines apply to this award as the other SIGSOFT awards.  Note, however, that the nomination package is distinct.  A single PDF containing the nomination package should be sumitted through the portal, and should contain: 
+Consult the [main SIGSOFT Awards page](/awards/sigsoftAwards/) for key dates and a link to the submission portal. The same intent to nominate and full package deadlines apply to this award as the other SIGSOFT awards.  Note, however, that the nomination package is distinct.  A single PDF containing the nomination package should be sumitted through the portal, and should contain: 
 
 * A single PDF containing the nomination package must be submitted through the portal to complete the submission by October 20, 2025, 2024 (two weeks after the registration deadline). The PDF should contain the following:
   1. Full name and affiliation of the nominated student

--- a/content/awards/anger.md
+++ b/content/awards/anger.md
@@ -14,8 +14,6 @@ The award provides a student member of SIGSOFT a stipend of up to $2000 to cover
 To be eligible for the award, a student must be a SIGSOFT member undertaing graduate rearch in a relevant field in an accredited college or university.
 
 Consult the [main SIGSOFT Awards page](/awards/sigsoftAwards/) for key dates and a link to the submission portal. The same intent to nominate and full package deadlines apply to this award as the other SIGSOFT awards.  Note, however, that the nomination package is distinct.  A single PDF containing the nomination package should be sumitted through the portal, and should contain: 
-
-* A single PDF containing the nomination package must be submitted through the portal to complete the submission by October 20, 2025, 2024 (two weeks after the registration deadline). The PDF should contain the following:
   1. Full name and affiliation of the nominated student
   2. Membership number (ACM/SIGSOFT)
   3. A synopsis of an original research proposal that the student is pursuing (2 page limit)

--- a/content/awards/dissertation.md
+++ b/content/awards/dissertation.md
@@ -11,12 +11,12 @@ The SIGSOFT Outstanding Doctoral Dissertation Award is presented annually to the
 The award is for an outstanding dissertation (in software engineering) dated within the year preceding the nomination due date. For nominations for the October 20, 2025, deadline, dissertations dated November, 2024 to November, 2025 are eligible. The dissertation date can refer to the “deposit date,” “committee approval date,” or another reasonable and relevant date, depending on the process followed by the nominee’s institution. However, please note that a dissertation can be nominated only once. Thus, if, e.g., the “deposit date” and “committee approval date” would fall into two award periods, the thesis cannot be nominated twice, and the nomination must choose one period. Especially given the time-specificity of this award, note that the selection committee is able to recognize multiple outstanding dissertations in a year, if circumstances warrant. 
 
 Consult the [main SIGSOFT Awards page](https://www2.sigsoft.org/awards/) for key
-dates, nomination and eligibility instructions, and a link to the submission
-portal.  
+dates, general nomination and eligibility instructions, and a link to the submission
+portal. 
 Nominee affiliations should specify both the degree-granting institution,
 and the nominee's current affiliation, if different. In _addition_ to the other
 nomination package requirements listed on the main awards page, the single
-nomination package PDF should additionally include:
+nomination package PDF should _also_ include:
   1. The student's advisor(s)
   2. One- to two-page summary of the nominee's dissertation (in English)
   3. List of nominee's publications (that were used as the basis of chapters in the nominated dissertation)

--- a/content/awards/dissertation.md
+++ b/content/awards/dissertation.md
@@ -10,7 +10,7 @@ The SIGSOFT Outstanding Doctoral Dissertation Award is presented annually to the
 
 The award is for an outstanding dissertation (in software engineering) dated within the year preceding the nomination due date. For nominations for the October 20, 2025, deadline, dissertations dated November, 2024 to November, 2025 are eligible. The dissertation date can refer to the “deposit date,” “committee approval date,” or another reasonable and relevant date, depending on the process followed by the nominee’s institution. However, please note that a dissertation can be nominated only once. Thus, if, e.g., the “deposit date” and “committee approval date” would fall into two award periods, the thesis cannot be nominated twice, and the nomination must choose one period. Especially given the time-specificity of this award, note that the selection committee is able to recognize multiple outstanding dissertations in a year, if circumstances warrant. 
 
-Consult the [main SIGSOFT Awards page](https://www2.sigsoft.org/awards/) for key
+Consult the [main SIGSOFT Awards page](/awards/sigsoftAwards/) for key
 dates, general nomination and eligibility instructions, and a link to the submission
 portal. 
 Nominee affiliations should specify both the degree-granting institution,

--- a/content/awards/dissertation.md
+++ b/content/awards/dissertation.md
@@ -6,25 +6,23 @@ aliases: "/awards/dissertationAward.html"
 
 ---
 
-The SIGSOFT Outstanding Doctoral Dissertation Award is presented annually to the author of an outstanding doctoral dissertation in the area of Software Engineering. The author of the winning dissertation will be invited to publish a dissertation summary in the SIGSOFT newsletter, Software Engineering Notes (SEN). The award includes a $1000 honorarium and a plaque for the author, which is presented at the International Conference on Software Engineering (ICSE), and funding support for the recipient to travel to ICSE to receive the award (including a registration to ICSE). A public citation for the award dissertation will be placed on the SIGSOFT web site. The award recipient also receives support for travel to ICSE up to $2500 within their home continent and up to $3000 outside their home continent, including airfare, hotel, and conference registration for ICSE.
+The SIGSOFT Outstanding Doctoral Dissertation Award is presented annually to the authors of outstanding doctoral dissertations in the area of Software Engineering. The author of winning dissertation(s) will be invited to publish a dissertation summary in the SIGSOFT newsletter, Software Engineering Notes (SEN). 
 
-The award is for an outstanding dissertation (in software engineering) dated within the year preceding the nomination due date. For nominations for the November 11, 2024, deadline, dissertations dated October 16, 2023 to November 10, 2024 are eligible. The dissertation date can refer to the “deposit date,” “committee approval date,” or another reasonable and relevant date, depending on the process followed by the nominee’s institution. However, please note that a dissertation can be nominated only once. Thus, if, e.g., the “deposit date” and “committee approval date” would fall into two award periods, the thesis cannot be nominated twice, and the nominee would have to choose one period.
+The award is for an outstanding dissertation (in software engineering) dated within the year preceding the nomination due date. For nominations for the October 20, 2025, deadline, dissertations dated November, 2024 to November, 2025 are eligible. The dissertation date can refer to the “deposit date,” “committee approval date,” or another reasonable and relevant date, depending on the process followed by the nominee’s institution. However, please note that a dissertation can be nominated only once. Thus, if, e.g., the “deposit date” and “committee approval date” would fall into two award periods, the thesis cannot be nominated twice, and the nomination must choose one period. Especially given the time-specificity of this award, note that the selection committee is able to recognize multiple outstanding dissertations in a year, if circumstances warrant. 
 
-
-
-To submit a nomination for the award, please use the [awards nomination portal](https://sigsoft-awards.hotcrp.com/). Please note that:
-
-* An intent to nominate must be submitted in the nomination system by October 6, 2025 (First Monday in October). The intent submission is very lightweight and only requires: (1) full name and afﬁliation of the nominee, (2) contact information of the nominator, and (3) some metadata. If no intent is received by the deadline, the nomination will be deemed late and not considered for this round of award selection.
-
-* A single PDF containing the nomination package must be submitted through the portal to complete the submission by October 20, 2025 (two weeks after the registration deadline). The PDF should contain the following:
-  1. Full name and afﬁliation of the nominee
+Consult the [main SIGSOFT Awards page](https://www2.sigsoft.org/awards/) for key
+dates, nomination and eligibility instructions, and a link to the submission
+portal.  
+Nominee affiliations should specify both the degree-granting institution,
+and the nominee's current affiliation, if different. In _addition_ to the other
+nomination package requirements listed on the main awards page, the single
+nomination package PDF should additionally include:
+  1. The student's advisor(s)
   2. One- to two-page summary of the nominee's dissertation (in English)
-  3. Link to download the nominee's dissertation (in any language)
-  4. List of nominee's publications (that were used as the basis of chapters in the nominated dissertation)
-  5. Succinct description of why the nominee is well-qualiﬁed for the award (200-500 words)
-  6. Up to three support letters (200-300 words will be sufﬁcient for each support letter, although longer statements of support are of course welcome). Each support letter must include the following sentence: "To the best of my knowledge, the candidate I am endorsing has not committed any action that violates the ACM Code of Ethics and ACM's Core Values.
+  3. List of nominee's publications (that were used as the basis of chapters in the nominated dissertation)
 
-The selection committee shall have the option to decline to make an award in a given year, if no suitable nominations are presented. If you have questions about this award, please contact sigsoft-dissertation-award (at) acm (dot) org.
+
+If you have questions about this award, please contact sigsoft-dissertation-award (at) acm (dot) org.
 
 ## Winners
 - 2025 Elizabeth Dinella, Neural Inference of Program Specifications, University of Pennsylvania, advisor: Mayur Naik.

--- a/content/awards/distinguishedService.md
+++ b/content/awards/distinguishedService.md
@@ -5,11 +5,10 @@ title: " Distinguished Service Award "
 aliases: "/awards/distinguishedServiceAward.html"
 ---
 
-This annual award is presented to individuals who have contributed dedicated and important service to the software engineering community. The award typically goes to a single person but can also be assigned to multiple people for joint contributions.
-
-Recipients receive a plaque engraved with their name and signed by the chair of SIGSOFT and share a $1000 honorarium. The award is presented by the SIGSOFT chair at ICSE during ICSE's award presentation session. The award recipient(s) each receive support for travel to ICSE up to $2500 within their home continent and up to $3000 outside their home continent, including airfare, hotel, and conference registration for ICSE.
-
-The selection committee solicits nominations from the software engineering community in a variety of ways including announcements in SIGSOFT's newsletter, Software Engineering Notes, and postings on appropriate newsgroups and websites. The committee considers all external nominations in the context of the nominees' specific and general service contributions to the overall software engineering community. The selection committee shall have the option to decline to make an award in a given year, if no suitable nominations are presented.
+This annual award is presented to individuals who have contributed dedicated and
+important service to the software engineering community. The committee considers
+all external nominations in the context of the nominees' specific and general
+service contributions to the overall software engineering community.
 
 Criteria that the committee considers in evaluating nominations include:
 
@@ -20,17 +19,7 @@ Criteria that the committee considers in evaluating nominations include:
 5. Length of time serving the software engineering community
 6. Other service contributions
 
-To submit a nomination for the award, please use the [awards nomination portal](https://sigsoft-awards.hotcrp.com/). Please note that:
-
-* An intent to nominate must be submitted in the nomination system by October 6, 2025. The intent submission is very lightweight and only requires: (1) full name(s) and afﬁliation(s) of the nominee(s), (2) contact information of the nominator, and (3) some metadata. If no intent is received by the deadline, the nomination will be deemed late and not considered for this round of award selection.
-
-* A single PDF containing the nomination package must be submitted through the portal to complete the submission by October 20, 2025 (two weeks after the registration deadline). The PDF should contain the following:
-  1. Full name(s) and afﬁliation(s) of the nominee(s)
-  2. Proposed citation (up to 25 words)
-  3. Succinct description of why the nominee(s) is well-qualiﬁed for the award (100-250 words)
-  4. Detailed nomination statement (no length limit, but please be reasonable)
-  5. Up to three support letters (200-300 words will be sufﬁcient for each support letter, although longer statements of support are of course welcome). Each support letter must include the following sentence: "To the best of my knowledge, the candidate(s) I am endorsing has not committed any action that violates the ACM Code of Ethics and ACM's Core Values.
-
+Consult the [main SIGSOFT Awards page](https://www2.sigsoft.org/awards/) for key dates, nomination and eligibility instructions, and a link to the submission portal. 
 
 If you have questions about this award, please contact sigsoft-service-award (at) acm (dot) org.
 
@@ -67,7 +56,7 @@ If you have questions about this award, please contact sigsoft-service-award (at
 - 1996	Rick Adrion
 - 1995	Tony Wasserman
 
-## Committee
+## Committees
 
 
 #### 2025

--- a/content/awards/distinguishedService.md
+++ b/content/awards/distinguishedService.md
@@ -19,7 +19,7 @@ Criteria that the committee considers in evaluating nominations include:
 5. Length of time serving the software engineering community
 6. Other service contributions
 
-Consult the [main SIGSOFT Awards page](https://www2.sigsoft.org/awards/) for key dates, nomination and eligibility instructions, and a link to the submission portal. 
+Consult the [main SIGSOFT Awards page](/awards/sigsoftAwards/) for key dates, nomination and eligibility instructions, and a link to the submission portal. 
 
 If you have questions about this award, please contact sigsoft-service-award (at) acm (dot) org.
 

--- a/content/awards/earlyCareerResearcher.md
+++ b/content/awards/earlyCareerResearcher.md
@@ -9,7 +9,7 @@ This award is presented to an individual or individuals who have made outstandin
 
 To be eligible for nomination for the award, individuals' most recent computer-related educational degree (baccalaureate, masters, or doctoral degree) must have been awarded no more than seven (7) years prior to the date of nomination. The 7-year window may be extended for extenuating circumstances such as parental or medical leave. Extenuating circumstances must be described in the nomination statement for the committee's deliberation (the committee reserves the right to accept or deny the consideration of the extenuating circumstances).
 
-Consult the [main SIGSOFT Awards page](https://www2.sigsoft.org/awards/) for key dates, nomination and eligibility instructions, and a link to the submission portal. Note the above eligibility requirement that additionally affects this award, and should be addressed in the nomination materials if necessary (i.e., if the nominator believes that extenuating circumstances should extend the typical 7-year eligibility requirement). 
+Consult the [main SIGSOFT Awards page](/awards/sigsoftAwards/) for key dates, nomination and eligibility instructions, and a link to the submission portal. Note the above eligibility requirement that additionally affects this award, and should be addressed in the nomination materials if necessary (i.e., if the nominator believes that extenuating circumstances should extend the typical 7-year eligibility requirement). 
 
 If you have questions about this award, please contact sigsoft-early-career-award (at) acm (dot) org.
 

--- a/content/awards/earlyCareerResearcher.md
+++ b/content/awards/earlyCareerResearcher.md
@@ -7,23 +7,11 @@ aliases: "/awards/earlyCareerResearcherAward.html"
 
 This award is presented to an individual or individuals who have made outstanding contributions in the area of software engineering as an early career investigator.
 
-To be eligible for nomination for the award, individuals' most recent computer-related educational degree (baccalaureate, masters, or doctoral degree) must have been awarded no more than seven years prior to the date of nomination. The 7-year window may be extended for extenuating circumstances such as parental or medical leave. Extenuating circumstances must be described in the nomination statement for the committee's deliberation (the committee reserves the right to accept or deny the consideration of the extenuating circumstances).
+To be eligible for nomination for the award, individuals' most recent computer-related educational degree (baccalaureate, masters, or doctoral degree) must have been awarded no more than seven (7) years prior to the date of nomination. The 7-year window may be extended for extenuating circumstances such as parental or medical leave. Extenuating circumstances must be described in the nomination statement for the committee's deliberation (the committee reserves the right to accept or deny the consideration of the extenuating circumstances).
 
-The award recipient receives a $1000 honorarium and a plaque engraved with their name and signed by the chair of SIGSOFT. The award is announced by the SIGSOFT chair at ICSE during ICSE's award presentation session. Each award recipient also receives travel support up to $2500 within their home continent and up to $3000 outside their home continent, including airfare, hotel, and conference registration to attend ICSE.
+Consult the [main SIGSOFT Awards page](https://www2.sigsoft.org/awards/) for key dates, nomination and eligibility instructions, and a link to the submission portal. Note the above eligibility requirement that additionally affects this award, and should be addressed in the nomination materials if necessary (i.e., if the nominator believes that extenuating circumstances should extend the typical 7-year eligibility requirement). 
 
-To submit a nomination for the award, please use the [awards nomination portal](https://sigsoft-awards.hotcrp.com/). Please note that:
-
-* An intent to nominate must be submitted in the nomination system by October 6, 2025 (First Monday in October). The intent submission is very lightweight and only requires: (1) full name and afﬁliation of the nominee, (2) contact information of the nominator, and (3) some metadata. If no intent is received by the deadline, the nomination will be deemed late and not considered for this round of award selection.
-
-* A single PDF containing the nomination package must be submitted through the portal to complete the submission by October 20, 2025 (two weeks after the registration deadline). The PDF should contain the following:
-
-  1. Full name and afﬁliation of the nominee
-  2. Proposed citation (up to 25 words)
-  3. Succinct description of why the nominee is well-qualiﬁed for the award (100-250 words)
-  4. Detailed nomination statement (no length limit, but please be reasonable)
-  5. Up to three support letters (200-300 words will be sufﬁcient for each support letter, although longer statements of support are of course welcome). Each support letter must include the following sentence: "To the best of my knowledge, the candidate I am endorsing has not committed any action that violates the ACM Code of Ethics and ACM's Core Values.
-
-The selection committee shall have the option to decline to make an award in a given year, if no suitable nominations are presented. If you have questions about this award, please contact sigsoft-early-career-award (at) acm (dot) org.
+If you have questions about this award, please contact sigsoft-early-career-award (at) acm (dot) org.
 
 ## Winners
 - 2025  Jie Zhang, King's College London, for pioneering contributions to software engineering for AI, significantly shaping and transforming the field of AI system testing.

--- a/content/awards/impactPaper.md
+++ b/content/awards/impactPaper.md
@@ -5,15 +5,18 @@ title: "ACM SIGSOFT Impact Paper Award"
 aliases: "/awards/impactPaperAward.html"
 ---
 
-The ACM SIGSOFT Impact Paper Award is presented annually to the author(s) of a paper presented at a SIGSOFT-sponsored or co-sponsored conference held at least 11 years prior to the award year. For the November 4, 2024 deadline, papers published in 2014 or before are eligible. In including all of SIGSOFT's conferences in the competition, this award recognizes the breadth and vitality of the software engineering community. The papers are judged by their influence since their publication. The award includes a $1000 honorarium to be split amongst the authors as they choose, an award plaque for each author, an invitation for the authors to present a keynote talk at the current year's annual ACM Joint European Software Engineering Conference and Symposium on the Foundations of Software Engineering (ESEC/FSE), as well as inclusion of a full-length paper in the ESEC/FSE conference proceedings. Up to three authors will be provided support for travel to ESEC/FSE, with each receiving up to $2500 within their home continent and up to $3000 outside their home continent, including airfare, hotel, and conference registration for ESEC/FSE.
+The ACM SIGSOFT Impact Paper Award is presented annually to the author(s) of a paper presented at a SIGSOFT-sponsored or co-sponsored conference held at least 11 years prior to the award year, e.g., for the October, 2025 deadline, papers published in 2025 or before or eligible. In including all of SIGSOFT's conferences in the competition, this award recognizes the breadth and vitality of the software engineering community. The papers are judged by their influence since their publication. 
 
-To submit a nomination for the award, please use the [awards nomination portal](https://sigsoft-awards.hotcrp.com/). Please note that:
+In addition to the awards honorarium, paper authors are invited to present a keynote talk at the current year's annual ACM Joint European Software Engineering Conference and Symposium on the Foundations of Software Engineering (ESEC/FSE), and include a full-length paper in the ESEC/FSE conference proceedings. Up to three authors will be provided support for travel to ESEC/FSE for this purpose. 
 
-* An intent to nominate must be submitted in the nomination system by October 6, 2025. The intent submission is very lightweight and only requires: (1) paper title along with the acronym and year of the SIGSOFT-sponsored conference the paper was published, (2) contact information of the nominator, and (3) some metadata. If no intent is received by the deadline, the nomination will be deemed late and not considered for this round of award selection.
 
-* A single PDF containing the nomination package must be submitted through the portal to complete the submission by October 20, 2025 (two weeks after the registration deadline). The PDF should contain the following information: (1) paper title; (2) authors; (3) name of the SIGSOFT-sponsored conference; (4) year the paper was published; (5) proposed citation (up to 25 words); (6) a succinct statement describing why the paper is impactful (200-500 words).
-
-The selection committee shall have the option to decline to make an award in a given year, if no suitable nominations are presented.
+Consult the [main SIGSOFT Awards page](https://www2.sigsoft.org/awards/) for key dates, nomination and eligibility instructions, and a link to the submission portal.  The same intent to nominate and full package deadlines apply to this award as the other SIGSOFT awards.  Note, however, that the nomination package is distinct.  A single PDF containing the nomination package should be sumitted through the portal, and should contain: 
+  1. Paper title
+  2. Paper authors, with contact information and current affiliations 
+  3. Name of the SIGSOFT-sponsored conference at which the paper was published
+  4. Year the paper was published
+  5. Proposed citation (up to 25 words)
+  6. A succinct statement describing why the paper is impactful (200-500 words is desirable).
 
 If you have questions about this award, please contact sigsoft-impact-award (at) acm (dot) org.
 

--- a/content/awards/impactPaper.md
+++ b/content/awards/impactPaper.md
@@ -7,8 +7,7 @@ aliases: "/awards/impactPaperAward.html"
 
 The ACM SIGSOFT Impact Paper Award is presented annually to the author(s) of a paper presented at a SIGSOFT-sponsored or co-sponsored conference held at least 11 years prior to the award year, e.g., for the October, 2025 deadline, papers published in 2015 or before or eligible. In including all of SIGSOFT's conferences in the competition, this award recognizes the breadth and vitality of the software engineering community. The papers are judged by their influence since their publication. 
 
-In addition to the honorarium, paper authors are invited to present a keynote talk at the current year's annual ACM Joint European Software Engineering Conference and Symposium on the Foundations of Software Engineering (ESEC/FSE), and include a full-length paper in the ESEC/FSE conference proceedings. Up to three authors will be provided support for travel to ESEC/FSE for this purpose. 
-
+In addition to the honorarium, paper authors are invited to present a keynote talk at the current year's annual International Conference on the Foundations of Software Engineering (ESEC/FSE), and include a full-length paper in the ESEC/FSE conference proceedings. Up to three authors will be provided support for travel to ESEC/FSE for this purpose. 
 
 Consult the [main SIGSOFT Awards page](/awards/sigsoftAwards/) for key dates, nomination and eligibility instructions, and a link to the submission portal.  The same intent to nominate and full package deadlines apply to this award as the other SIGSOFT awards.  Note, however, that the nomination package is distinct.  A single PDF containing the nomination package should be sumitted through the portal, and should contain: 
   1. Paper title

--- a/content/awards/impactPaper.md
+++ b/content/awards/impactPaper.md
@@ -5,9 +5,9 @@ title: "ACM SIGSOFT Impact Paper Award"
 aliases: "/awards/impactPaperAward.html"
 ---
 
-The ACM SIGSOFT Impact Paper Award is presented annually to the author(s) of a paper presented at a SIGSOFT-sponsored or co-sponsored conference held at least 11 years prior to the award year, e.g., for the October, 2025 deadline, papers published in 2025 or before or eligible. In including all of SIGSOFT's conferences in the competition, this award recognizes the breadth and vitality of the software engineering community. The papers are judged by their influence since their publication. 
+The ACM SIGSOFT Impact Paper Award is presented annually to the author(s) of a paper presented at a SIGSOFT-sponsored or co-sponsored conference held at least 11 years prior to the award year, e.g., for the October, 2025 deadline, papers published in 2015 or before or eligible. In including all of SIGSOFT's conferences in the competition, this award recognizes the breadth and vitality of the software engineering community. The papers are judged by their influence since their publication. 
 
-In addition to the awards honorarium, paper authors are invited to present a keynote talk at the current year's annual ACM Joint European Software Engineering Conference and Symposium on the Foundations of Software Engineering (ESEC/FSE), and include a full-length paper in the ESEC/FSE conference proceedings. Up to three authors will be provided support for travel to ESEC/FSE for this purpose. 
+In addition to the honorarium, paper authors are invited to present a keynote talk at the current year's annual ACM Joint European Software Engineering Conference and Symposium on the Foundations of Software Engineering (ESEC/FSE), and include a full-length paper in the ESEC/FSE conference proceedings. Up to three authors will be provided support for travel to ESEC/FSE for this purpose. 
 
 
 Consult the [main SIGSOFT Awards page](https://www2.sigsoft.org/awards/) for key dates, nomination and eligibility instructions, and a link to the submission portal.  The same intent to nominate and full package deadlines apply to this award as the other SIGSOFT awards.  Note, however, that the nomination package is distinct.  A single PDF containing the nomination package should be sumitted through the portal, and should contain: 

--- a/content/awards/impactPaper.md
+++ b/content/awards/impactPaper.md
@@ -10,7 +10,7 @@ The ACM SIGSOFT Impact Paper Award is presented annually to the author(s) of a p
 In addition to the honorarium, paper authors are invited to present a keynote talk at the current year's annual ACM Joint European Software Engineering Conference and Symposium on the Foundations of Software Engineering (ESEC/FSE), and include a full-length paper in the ESEC/FSE conference proceedings. Up to three authors will be provided support for travel to ESEC/FSE for this purpose. 
 
 
-Consult the [main SIGSOFT Awards page](https://www2.sigsoft.org/awards/) for key dates, nomination and eligibility instructions, and a link to the submission portal.  The same intent to nominate and full package deadlines apply to this award as the other SIGSOFT awards.  Note, however, that the nomination package is distinct.  A single PDF containing the nomination package should be sumitted through the portal, and should contain: 
+Consult the [main SIGSOFT Awards page](/awards/sigsoftAwards/) for key dates, nomination and eligibility instructions, and a link to the submission portal.  The same intent to nominate and full package deadlines apply to this award as the other SIGSOFT awards.  Note, however, that the nomination package is distinct.  A single PDF containing the nomination package should be sumitted through the portal, and should contain: 
   1. Paper title
   2. Paper authors, with contact information and current affiliations 
   3. Name of the SIGSOFT-sponsored conference at which the paper was published

--- a/content/awards/influentialEducator.md
+++ b/content/awards/influentialEducator.md
@@ -5,23 +5,12 @@ title: "Influential Educator Award"
 aliases: "/awards/influentialEducatorAward.html"
 ---
 
-Education is vital to the advancement of the research and practice of Software Engineering. Yet, the contributions of an educator often go unnoticed, except perhaps by those closest to the educator. The SIGSOFT Influential Educator Award is presented annually to an educator or educators who have made significant contributions to, and impact on, the field of software engineering with his or her accomplishments as a teacher, mentor, researcher (in education or learning), author, and/or policy maker. The award may be made to multiple collaborators for joint contributions, such as a co-authored text book.
-
-The award recipients share a $1000 honorarium, and each recipient receives a plaque engraved with their name and signed by the chair of SIGSOFT. The award is presented by the SIGSOFT chair at ICSE during ICSE's award presentation session. Each award recipient also receives support for travel to ICSE up to $2500 within their home continent and up to $3000 outside their home continent, including airfare, hotel, and conference registration for ICSE.
-
-To submit a nomination for the award, please use the [awards nomination portal](https://sigsoft-awards.hotcrp.com/). Please note that:
-* An intent to nominate must be submitted in the nomination system by October 6, 2025 (first Monday in October). The intent submission is very lightweight and only requires: (1) full name(s) and afﬁliation(s) of the nominee(s), (2) contact information of the nominator, and (3) some metadata. If no intent is received by the deadline, the nomination will be deemed late and not considered for this round of award selection.
-
-* A single PDF containing the nomination package must be submitted through the portal to complete the submission by October 20, 2025 (two weeks after the registration deadline). The PDF should contain the following:
-
-    1. Full name(s) and afﬁliation(s) of the nominee(s)
-    2. Proposed citation (up to 25 words)
-    3. Succinct description of why the nominee(s) is well-qualiﬁed for the award (100-250 words)
-    4. Detailed nomination statement (no length limit, but please be reasonable)
-    5. Up to three support letters (200-300 words will be sufﬁcient for each support letter, although longer statements of support are of course welcome). Each support letter must include the following sentence: "To the best of my knowledge, the candidate I am endorsing has not committed any action that violates the ACM Code of Ethics and ACM's Core Values.
+Education is vital to the advancement of the research and practice of Software Engineering. Yet, the contributions of an educator often go unnoticed, except perhaps by those closest to the educator. The SIGSOFT Influential Educator Award is presented annually to an educator or educators who have made significant contributions to, and impact on, the field of software engineering with his or her accomplishments as a teacher, mentor, researcher (in education or learning), author, and/or policy maker. 
 
 
-The selection committee shall have the option to decline to make an award in a given year, if no suitable nominations are presented. If you have questions about this award, please contact sigsoft-educator-award (at) acm (dot) org.
+Consult the [main SIGSOFT Awards page](https://www2.sigsoft.org/awards/) for key dates, nomination instructions, and a link to the submission portal. 
+
+If you have questions about this award, please contact sigsoft-educator-award (at) acm (dot) org.
 
 ## Winners
 - 2025  Andreas Zeller, CISPA and Saarland University, for significant contributions and important innovations in automated software engineering education.

--- a/content/awards/influentialEducator.md
+++ b/content/awards/influentialEducator.md
@@ -8,7 +8,7 @@ aliases: "/awards/influentialEducatorAward.html"
 Education is vital to the advancement of the research and practice of Software Engineering. Yet, the contributions of an educator often go unnoticed, except perhaps by those closest to the educator. The SIGSOFT Influential Educator Award is presented annually to an educator or educators who have made significant contributions to, and impact on, the field of software engineering with his or her accomplishments as a teacher, mentor, researcher (in education or learning), author, and/or policy maker. 
 
 
-Consult the [main SIGSOFT Awards page](https://www2.sigsoft.org/awards/) for key dates, nomination instructions, and a link to the submission portal. 
+Consult the [main SIGSOFT Awards page](/awards/sigsoftAwards/) for key dates, nomination instructions, and a link to the submission portal. 
 
 If you have questions about this award, please contact sigsoft-educator-award (at) acm (dot) org.
 

--- a/content/awards/outstandingResearch.md
+++ b/content/awards/outstandingResearch.md
@@ -7,20 +7,9 @@ aliases: "/awards/outstandingResearchAward.html"
 
 This award is presented to an individual or individuals who have made significant and lasting research contributions to the theory or practice of software engineering.
 
-The award recipients share a $1000 honorarium, and each recipient receives a plaque engraved with their name and signed by the chair of SIGSOFT. The award is announced by the SIGSOFT chair at ICSE during ICSE's award presentation session. The award recipients are invited to give a keynote presentation at the ICSE conference in the year in which the award is made. Each award recipient also receives travel support up to $2500 within their home continent and up to $3000 outside their home continent, including airfare, hotel, and conference registration to attend the ICSE conference.
+In addition to the typical awards benefits, recipients are invited to give a keynote presentation at the ICSE conference in the year in which the award is made.
 
-The selection committee solicits nominations from the software engineering community in a variety of ways including announcements in SIGSOFT's newsletter, Software Engineering Notes, and postings on appropriate newsgroups and websites. The committee considers all external nominations in the context of the nominees' research contributions to software engineering. The selection committee shall also have the option to decline to make an award in a given year, if no suitable nominations are presented.
-
-To submit a nomination for the award, please use the [awards nomination portal](https://sigsoft-awards.hotcrp.com/). Please note that:
-
-* An intent to nominate must be submitted in the nomination system by October 6, 2025. The intent submission is very lightweight and only requires: (1) full name(s) and afﬁliation(s) of the nominee(s), (2) contact information of the nominator, and (3) some metadata. If no intent is received by the deadline, the nomination will be deemed late and not considered for this round of award selection.
-
-* A single PDF containing the nomination package must be submitted through the portal to complete the submission by October 20, 2025 (two weeks after the registration deadline). The PDF should contain the following:
-  1. Full name(s) and afﬁliation(s) of the nominee(s)
-  2. Proposed citation (up to 25 words)
-  3. Succinct description of why the nominee(s) is well-qualiﬁed for the award (100-250 words)
-  4. Detailed nomination statement (no length limit, but please be reasonable)
-  5. Up to three support letters (200-300 words will be sufﬁcient for each support letter, although longer statements of support are of course welcome). Each support letter must include the following sentence: "To the best of my knowledge, the candidate I am endorsing has not committed any action that violates the ACM Code of Ethics and ACM's Core Values.
+Consult the [main SIGSOFT Awards page](https://www2.sigsoft.org/awards/) for key dates, nomination and eligibility instructions, and a link to the submission portal. 
 
 If you have questions about this award, please contact sigsoft-research-award (at) acm (dot) org.
 

--- a/content/awards/outstandingResearch.md
+++ b/content/awards/outstandingResearch.md
@@ -9,7 +9,7 @@ This award is presented to an individual or individuals who have made significan
 
 In addition to the typical awards benefits, recipients are invited to give a keynote presentation at the ICSE conference in the year in which the award is made.
 
-Consult the [main SIGSOFT Awards page](https://www2.sigsoft.org/awards/) for key dates, nomination and eligibility instructions, and a link to the submission portal. 
+Consult the [main SIGSOFT Awards page](/awards/sigsoftAwards/) for key dates, nomination and eligibility instructions, and a link to the submission portal. 
 
 If you have questions about this award, please contact sigsoft-research-award (at) acm (dot) org.
 

--- a/content/awards/sigsoftAwards.md
+++ b/content/awards/sigsoftAwards.md
@@ -2,5 +2,124 @@
 weight: 1
 bookFlatSection: true
 title: "SIGSOFT Awards Overview"
-aliases: "/awards/outstandingResearchAward.html"
+aliases: "/awards/sigsoftAwards.html"
 ---
+
+# ACM SIGSOFT Awards
+
+ACM SIGSOFT recognizes excellence in software engineering through several
+awards, presented annually. These awards honor outstanding contributions to our
+field, throughout our colleagues' careers. Awards are typically presented to
+individuals, but can be awarded jointly when circumstances warrant, such as for
+joint contributions.  
+
+## Award Categories
+
+### Senior Awards
+- **[Distinguished Service
+Award](https://www2.sigsoft.org/awards/distinguishedservice/)** - Recognizes
+dedicated and important service to the software engineering community 
+- **[Outstanding Research Award](https://www2.sigsoft.org/awards/outstandingresearch/)** - Honors
+significant and lasting research contributions to the theory or practice of
+software engineering
+- **[Influential Educator Award](https://www2.sigsoft.org/awards/influentialeducator/)** - Celebrates
+significant contributions and impact on software engineering education as a
+teacher, mentor, researcher, author, and/or policy maker
+
+### Junior Awards
+- **[Outstanding Doctoral Dissertation Award](https://www2.sigsoft.org/awards/dissertation/)** - Presented to the author of an outstanding doctoral dissertation in software engineering
+- **[Early Career Researcher Award](https://www2.sigsoft.org/awards/earlycareerresearcher/)** - Recognizes outstanding contributions by early career investigators
+- **[Frank Anger Memorial Award](https://www2.sigsoft.org/awards/anger/)** - Student travel award promoting cross-disciplinary research between SIGSOFT and SIGBED communities
+
+### Impact Award
+- **[Impact Paper Award](https://www2.sigsoft.org/awards/impactpaper/)** - Recognizes papers from SIGSOFT conferences that have had significant influence
+
+## Nomination Process
+
+All awards follow a similar nomination process, with two key deadlines:
+
+### Important Dates for 2025
+- **Intent to Nominate Deadline: October 6, 2025** (First Monday in October)
+- **Full Nomination Package Deadline: October 20, 2025** (Two weeks after intent deadline)
+
+### How to Nominate
+1. Submit an **intent to nominate** through the [awards nomination portal](https://sigsoft-awards.hotcrp.com/) by the first deadline
+   - This is lightweight, requiring only basic information about the nominee(s)
+   and nominator
+   - Intentions to nominate must be received by the deadline for a candidate to
+   be considered in the current award year. 
+2. Submit the complete nomination package as a single PDF by the second deadline
+
+Nominators of candidates who are not selected in a given award year will be
+given the option to reuse nomination materials unmodified for up to two
+consecutive additional years.
+
+### Shared Nomination Requirements and eligibility
+
+All nomination packages should include:
+- Full name(s) and affiliation(s) of nominee(s)
+- Proposed citation (up to 25 words)
+- Succinct description of qualifications (100-250 words)
+- Detailed nomination statement
+- Up to three support letters (200-300 words each)
+- **Important**: Each support letter must include: *"To the best of my knowledge, the candidate I am endorsing has not committed any action that violates the ACM Code of Ethics and ACM's Core Values."*
+
+
+#### Eligibility 
+
+- Self nominations are permitted.
+- The same individual cannot be nominated for different SIGSOFT awards in the
+  same year.  However, the committee reserves the right to consider an
+  individual for a different award than the one for which they are nominated, if
+  they deem it more suitable.
+- In general, SIGSOFT will not select individuals recognized  by an award from
+  another professional society to receive an equivalent or 
+  substantially similar SIGSOFT award.  Nominations of such individuals are
+  permitted, but must include a clear justification for the nomination that articulates
+  and justifies the special circumstances that motivate considering the nominee
+  for such a substantially similar award.  
+
+*Note: Certain awards have additional requirements and eligibility
+ restrictions. Consult individual award pages for complete details.*
+
+
+## Award Benefits
+
+Awards are presented to recipients at plenary sessions of major conferences
+(typically ICSE).  Recipients typically receive a stipend for travel support to
+receive that award, along with an honorarium and a commemorative plaque.
+Consult individual awards pages for complete details. 
+
+## Selection Process
+
+Each award has a dedicated selection committee that evaluates nominations based
+on specific criteria. Committees have the option to decline making an award if
+no suitable nominations are received. 
+
+### 2025 Committee Leadership
+- **Senior Awards Committee Chair**: Lionel Briand, University of Ottawa, Canada and LERO, University of Limerick, Ireland
+- **Junior Awards Committee Chair**: Aldeida Aleti, Monash University, Australia
+- **Impact Paper Award Committee Chair**: Abhik Roychoudhury, National University of Singapore, Singapore
+- **SIGSOFT Chair**: Marsha Chechik, University of Toronto, Canada
+- **SIGSOFT Award Chair**: Claire Le Goues, Carnegie Mellon University, USA
+
+## Contact Information
+
+The Awards Chair may be reached at sigsoft-awards-chair (at) acm (dot) org
+
+For questions about specific awards:
+- Distinguished Service: sigsoft-service-award (at) acm (dot) org
+- Outstanding Research: sigsoft-research-award (at) acm (dot) org
+- Influential Educator: sigsoft-educator-award (at) acm (dot) org
+- Outstanding Doctoral Dissertation: sigsoft-dissertation-award (at) acm (dot) org
+- Early Career Researcher: sigsoft-early-career-award (at) acm (dot) org
+- Frank Anger Memorial: sigsoft-angermemorial-award (at) acm (dot) org
+- Impact Paper: sigsoft-impact-award (at) acm (dot) org
+
+
+
+## Past Recipients
+
+Visit individual award pages to see the complete list of past recipients and
+learn about their contributions to the software engineering community.
+

--- a/content/awards/sigsoftAwards.md
+++ b/content/awards/sigsoftAwards.md
@@ -11,7 +11,7 @@ ACM SIGSOFT recognizes excellence in software engineering through several
 awards, presented annually. These awards honor outstanding contributions to our
 field, throughout our colleagues' careers. Awards are typically presented to
 individuals, but can be awarded jointly when circumstances warrant, such as for
-joint contributions.  
+joint contributions.  Awards are not given posthumously.
 
 ## Award Categories
 
@@ -79,7 +79,7 @@ Nomination packages for all but the Impact Paper and Frank Anger awards should i
   substantially similar SIGSOFT award.  Nominations of such individuals are
   permitted, but must include a clear justification for the nomination that articulates
   and justifies the special circumstances that motivate considering the nominee
-  for such a substantially similar award.  
+  for such a substantially similar award (the committee reserves the right to accept or deny the justification). 
 
 
 ## Award Benefits

--- a/content/awards/sigsoftAwards.md
+++ b/content/awards/sigsoftAwards.md
@@ -85,15 +85,15 @@ In general, the selection committee shall have the option to decline to make an 
 
 ## Award Benefits
 
+Awards are presented by SIGSOFT at ICSE during ICSE’s award presentation session.
 Recipients receive a plaque engraved with their name and signed by the chair of
-SIGSOFT and share a $1000 honorarium. Most awards are presented by SIGSOFT at
-ICSE during ICSE’s award presentation session.
+SIGSOFT.
 
-For awards besides the Frank Anger award, recipient(s) receive support for
-travel to either ICSE (or ESEC/FSE, for the Impact Paper) of up to $2500 within
-their home continent, and up to $3000 outside their home continent.
+Recipient(s) of the Outstanding Research, Influential Educator, Distinguished Service, Early Career Researcher, and Outstanding Dissertation awards, receive a $1000 honorarium and support for
+travel to ICSE of up to $2500 within
+their home continent, and up to $3000 outside their home continent. Recipients of the Impact Paper award share a $1000 honorarium, and receive comparable support to travel to ESEC/FSE.  
 
-Some awards include other benefits; consult individual pages for  award-specific details. 
+Some awards include other benefits; consult individual pages for award-specific details. 
 
 ## Process
 

--- a/content/awards/sigsoftAwards.md
+++ b/content/awards/sigsoftAwards.md
@@ -92,9 +92,9 @@ For awards besides the Frank Anger award, recipient(s) receive support for
 travel to either ICSE (or ESEC/FSE, for the Impact Paper) of up to $2500 within
 their home continent, and up to $3000 outside their home continent.
 
-Some awards include other benefits; individual pages for other award-specific details. 
+Some awards include other benefits; consult individual pages for  award-specific details. 
 
-## Selection Process
+## Process
 
 SIGSOFT solicits nominations from the software engineering community in a
 variety of ways including announcements in SIGSOFT's newsletter, Software

--- a/content/awards/sigsoftAwards.md
+++ b/content/awards/sigsoftAwards.md
@@ -56,14 +56,16 @@ consecutive additional years.
 
 ### Shared Nomination Requirements and eligibility
 
-All nomination packages should include:
+*Note: Certain awards have additional or different requirements and eligibility
+ restrictions. Consult individual award pages for complete details.*
+
+Nomination packages for all but the Impact Paper and Frank Anger awards should include:
 - Full name(s) and affiliation(s) of nominee(s)
 - Proposed citation (up to 25 words)
 - Succinct description of why the nominee(s) is well-qualified for the award (100-250 words)
 - Detailed nomination statement (no length limit, but please be reasonable)
 - Up to three support letters (200-300 words is sufficient for support letters, although longer statements of support are of course welcome)
 - **Important**: Each support letter must include the following sentence: *"To the best of my knowledge, the candidate I am endorsing has not committed any action that violates the ACM Code of Ethics and ACM's Core Values."*
-
 
 #### Eligibility 
 
@@ -79,18 +81,16 @@ All nomination packages should include:
   and justifies the special circumstances that motivate considering the nominee
   for such a substantially similar award.  
 
-*Note: Certain awards have additional requirements and eligibility
- restrictions. Consult individual award pages for complete details.*
-
 
 ## Award Benefits
 
-For all awards except the Frank Anger SIGBED Award, recipients receive a plaque
-engraved with their name and signed by the chair of SIGSOFT and share a $1000
-honorarium. The award is presented by SIGSOFT at ICSE during ICSE’s award
-presentation session. The award recipient(s) each receive support for travel to
-ICSE up to $2500 within their home continent and up to $3000 outside their home
-continent.
+Recipients receive a plaque engraved with their name and signed by the chair of
+SIGSOFT and share a $1000 honorarium. Most awards are presented by SIGSOFT at
+ICSE during ICSE’s award presentation session.
+
+For awards besides the Frank Anger award, recipient(s) receive support for
+travel to either ICSE (or ESEC/FSE, for the Impact Paper) of up to $2500 within
+their home continent, and up to $3000 outside their home continent.
 
 Some awards include other benefits; individual pages for other award-specific details. 
 

--- a/content/awards/sigsoftAwards.md
+++ b/content/awards/sigsoftAwards.md
@@ -81,6 +81,7 @@ Nomination packages for all but the Impact Paper and Frank Anger awards should i
   and justifies the special circumstances that motivate considering the nominee
   for such a substantially similar award (the committee reserves the right to accept or deny the justification). 
 
+In general, the selection committee shall have the option to decline to make an award in a given year, if no suitable nominations are received.
 
 ## Award Benefits
 

--- a/content/awards/sigsoftAwards.md
+++ b/content/awards/sigsoftAwards.md
@@ -44,10 +44,10 @@ All awards follow a similar nomination process, with two key deadlines:
 
 ### How to Nominate
 1. Submit an **intent to nominate** through the [awards nomination portal](https://sigsoft-awards.hotcrp.com/) by the first deadline
-   - This is lightweight, requiring only basic information about the nominee(s)
-   and nominator
-   - Intentions to nominate must be received by the deadline for a candidate to
-   be considered in the current award year. 
+   - The intent submission is very lightweight and only requires: (1) full name(s) and
+   afﬁliation(s) of the nominee(s), (2) contact information of the nominator,
+   and (3) some metadata. If no intent is received by the deadline, the
+   nomination will be deemed late and will not be considered in the current award year. 
 2. Submit the complete nomination package as a single PDF by the second deadline
 
 Nominators of candidates who are not selected in a given award year will be
@@ -59,10 +59,10 @@ consecutive additional years.
 All nomination packages should include:
 - Full name(s) and affiliation(s) of nominee(s)
 - Proposed citation (up to 25 words)
-- Succinct description of qualifications (100-250 words)
-- Detailed nomination statement
-- Up to three support letters (200-300 words each)
-- **Important**: Each support letter must include: *"To the best of my knowledge, the candidate I am endorsing has not committed any action that violates the ACM Code of Ethics and ACM's Core Values."*
+- Succinct description of why the nominee(s) is well-qualified for the award (100-250 words)
+- Detailed nomination statement (no length limit, but please be reasonable)
+- Up to three support letters (200-300 words is sufficient for support letters, although longer statements of support are of course welcome)
+- **Important**: Each support letter must include the following sentence: *"To the best of my knowledge, the candidate I am endorsing has not committed any action that violates the ACM Code of Ethics and ACM's Core Values."*
 
 
 #### Eligibility 
@@ -85,23 +85,30 @@ All nomination packages should include:
 
 ## Award Benefits
 
-Awards are presented to recipients at plenary sessions of major conferences
-(typically ICSE).  Recipients typically receive a stipend for travel support to
-receive that award, along with an honorarium and a commemorative plaque.
-Consult individual awards pages for complete details. 
+For all awards except the Frank Anger SIGBED Award, recipients receive a plaque
+engraved with their name and signed by the chair of SIGSOFT and share a $1000
+honorarium. The award is presented by SIGSOFT at ICSE during ICSE’s award
+presentation session. The award recipient(s) each receive support for travel to
+ICSE up to $2500 within their home continent and up to $3000 outside their home
+continent.
+
+Some awards include other benefits; individual pages for other award-specific details. 
 
 ## Selection Process
 
-Each award has a dedicated selection committee that evaluates nominations based
-on specific criteria. Committees have the option to decline making an award if
-no suitable nominations are received. 
+SIGSOFT solicits nominations from the software engineering community in a
+variety of ways including announcements in SIGSOFT's newsletter, Software
+Engineering Notes, and postings on appropriate newsgroups and websites. Each
+award's selection committee evaluates nominations based on award-specific criteria.
+Committees have the option to decline making an award if no suitable nominations
+are received.
 
 ### 2025 Committee Leadership
 - **Senior Awards Committee Chair**: Lionel Briand, University of Ottawa, Canada and LERO, University of Limerick, Ireland
 - **Junior Awards Committee Chair**: Aldeida Aleti, Monash University, Australia
 - **Impact Paper Award Committee Chair**: Abhik Roychoudhury, National University of Singapore, Singapore
-- **SIGSOFT Chair**: Marsha Chechik, University of Toronto, Canada
-- **SIGSOFT Award Chair**: Claire Le Goues, Carnegie Mellon University, USA
+- **SIGSOFT Chair** (non-voting): Marsha Chechik, University of Toronto, Canada
+- **SIGSOFT Award Chair** (non-voting): Claire Le Goues, Carnegie Mellon University, USA
 
 ## Contact Information
 


### PR DESCRIPTION
This change puts content common to all SIGSOFT awards on the main SIGSOFT awards page (e.g., dates, link to nomination portal, and common nomination requirements).  I have three questions for reviewers.

1. This PR does not move the committees to the main page, though this may be desirable; the junior awards are handled by a single awards committee, as are the senior awards, which results in duplication (and risks of typos/needing to update the same thing in multiple places).  However, this may clutter the main page too much. What do you think?
2. Is the information clearly presented?  There are some very minor differences between some (but not all) awards eligibility/requirements/benefits that I want to ensure are presented well, between the main awards page and the individual pages.
3. Specifically for people like Marsha, Tom, or David: what do you think of the general eligibility content on the main page? This is a draft based on our discussion over the past several months. 

Thanks, all!