### PR TITLE
(should) fix the main sigsoft awards page 404ing from subpages.

### DIFF
--- a/content/awards/anger.md
+++ b/content/awards/anger.md
@@ -13,7 +13,7 @@ The award provides a student member of SIGSOFT a stipend of up to $2000 to cover
 
 To be eligible for the award, a student must be a SIGSOFT member undertaking graduate research in a relevant field in an accredited college or university.
 
-Consult the [main SIGSOFT Awards page](/awards/sigsoftAwards/) for key dates and a link to the submission portal. The same intent to nominate and full package deadlines apply to this award as the other SIGSOFT awards.  Note, however, that the nomination package is distinct.  A single PDF containing the nomination package should be submitted through the portal, and should contain: 
+Consult the [main SIGSOFT Awards page](/awards/sigsoftawards/) for key dates and a link to the submission portal. The same intent to nominate and full package deadlines apply to this award as the other SIGSOFT awards.  Note, however, that the nomination package is distinct.  A single PDF containing the nomination package should be submitted through the portal, and should contain: 
   1. Full name and affiliation of the nominated student
   2. Membership number (ACM/SIGSOFT)
   3. A synopsis of an original research proposal that the student is pursuing (2 page limit)

--- a/content/awards/dissertation.md
+++ b/content/awards/dissertation.md
@@ -10,7 +10,7 @@ The SIGSOFT Outstanding Doctoral Dissertation Award is presented annually to the
 
 The award is for an outstanding dissertation (in software engineering) dated within the year preceding the nomination due date. For nominations for the October 20, 2025, deadline, dissertations dated November, 2024 to November, 2025 are eligible. The dissertation date can refer to the “deposit date,” “committee approval date,” or another reasonable and relevant date, depending on the process followed by the nominee’s institution. However, please note that a dissertation can be nominated only once. Thus, if, e.g., the “deposit date” and “committee approval date” would fall into two award periods, the thesis cannot be nominated twice, and the nomination must choose one period. Especially given the time-specificity of this award, note that the selection committee is able to recognize multiple outstanding dissertations in a year, if circumstances warrant. 
 
-Consult the [main SIGSOFT Awards page](/awards/sigsoftAwards/) for key
+Consult the [main SIGSOFT Awards page](/awards/sigsoftawards/) for key
 dates, general nomination and eligibility instructions, and a link to the submission
 portal. 
 Nominee affiliations should specify both the degree-granting institution,

--- a/content/awards/distinguishedService.md
+++ b/content/awards/distinguishedService.md
@@ -19,7 +19,7 @@ Criteria that the committee considers in evaluating nominations include:
 5. Length of time serving the software engineering community
 6. Other service contributions
 
-Consult the [main SIGSOFT Awards page](/awards/sigsoftAwards/) for key dates, nomination and eligibility instructions, and a link to the submission portal. 
+Consult the [main SIGSOFT Awards page](/awards/sigsoftawards/) for key dates, nomination and eligibility instructions, and a link to the submission portal. 
 
 If you have questions about this award, please contact sigsoft-service-award (at) acm (dot) org.
 

--- a/content/awards/earlyCareerResearcher.md
+++ b/content/awards/earlyCareerResearcher.md
@@ -9,7 +9,7 @@ This award is presented to an individual or individuals who have made outstandin
 
 To be eligible for nomination for the award, individuals' most recent computer-related educational degree (baccalaureate, masters, or doctoral degree) must have been awarded no more than seven (7) years prior to the date of nomination. The 7-year window may be extended for extenuating circumstances such as parental or medical leave. Extenuating circumstances must be described in the nomination statement for the committee's deliberation (the committee reserves the right to accept or deny the consideration of the extenuating circumstances).
 
-Consult the [main SIGSOFT Awards page](/awards/sigsoftAwards/) for key dates, nomination and eligibility instructions, and a link to the submission portal. Note the above eligibility requirement that additionally affects this award, and should be addressed in the nomination materials if necessary (i.e., if the nominator believes that extenuating circumstances should extend the typical 7-year eligibility requirement). 
+Consult the [main SIGSOFT Awards page](/awards/sigsoftawards/) for key dates, nomination and eligibility instructions, and a link to the submission portal. Note the above eligibility requirement that additionally affects this award, and should be addressed in the nomination materials if necessary (i.e., if the nominator believes that extenuating circumstances should extend the typical 7-year eligibility requirement). 
 
 If you have questions about this award, please contact sigsoft-early-career-award (at) acm (dot) org.
 

--- a/content/awards/impactPaper.md
+++ b/content/awards/impactPaper.md
@@ -9,7 +9,7 @@ The ACM SIGSOFT Impact Paper Award is presented annually to the author(s) of a p
 
 In addition to the honorarium, paper authors are invited to present a keynote talk at the current year's annual International Conference on the Foundations of Software Engineering (FSE), and include a full-length paper in the FSE conference proceedings. Up to three authors will be provided support for travel to FSE for this purpose. 
 
-Consult the [main SIGSOFT Awards page](/awards/sigsoftAwards/) for key dates, nomination and eligibility instructions, and a link to the submission portal.  The same intent to nominate and full package deadlines apply to this award as the other SIGSOFT awards.  Note, however, that the nomination package is distinct.  A single PDF containing the nomination package should be sumitted through the portal, and should contain: 
+Consult the [main SIGSOFT Awards page](/awards/sigsoftawards/) for key dates, nomination and eligibility instructions, and a link to the submission portal.  The same intent to nominate and full package deadlines apply to this award as the other SIGSOFT awards.  Note, however, that the nomination package is distinct.  A single PDF containing the nomination package should be sumitted through the portal, and should contain: 
   1. Paper title
   2. Paper authors, with contact information and current affiliations 
   3. Name of the SIGSOFT-sponsored conference at which the paper was published

--- a/content/awards/influentialEducator.md
+++ b/content/awards/influentialEducator.md
@@ -8,7 +8,7 @@ aliases: "/awards/influentialEducatorAward.html"
 Education is vital to the advancement of the research and practice of Software Engineering. Yet, the contributions of an educator often go unnoticed, except perhaps by those closest to the educator. The SIGSOFT Influential Educator Award is presented annually to an educator or educators who have made significant contributions to, and impact on, the field of software engineering with his or her accomplishments as a teacher, mentor, researcher (in education or learning), author, and/or policy maker. 
 
 
-Consult the [main SIGSOFT Awards page](/awards/sigsoftAwards/) for key dates, nomination instructions, and a link to the submission portal. 
+Consult the [main SIGSOFT Awards page](/awards/sigsoftawards/) for key dates, nomination instructions, and a link to the submission portal. 
 
 If you have questions about this award, please contact sigsoft-educator-award (at) acm (dot) org.
 

--- a/content/awards/outstandingResearch.md
+++ b/content/awards/outstandingResearch.md
@@ -9,7 +9,7 @@ This award is presented to an individual or individuals who have made significan
 
 In addition to the typical awards benefits, recipients are invited to give a keynote presentation at the ICSE conference in the year in which the award is made.
 
-Consult the [main SIGSOFT Awards page](/awards/sigsoftAwards/) for key dates, nomination and eligibility instructions, and a link to the submission portal. 
+Consult the [main SIGSOFT Awards page](/awards/sigsoftawards/) for key dates, nomination and eligibility instructions, and a link to the submission portal. 
 
 If you have questions about this award, please contact sigsoft-research-award (at) acm (dot) org.
 


### PR DESCRIPTION
The links to the main SIGSOFT awards page are all throwing a 404 error, I think because of the capital A in this markdown. The same URL with a lowercase a loads.  This should fix it. 