### PR TITLE
fix the GitHub action files that lead to conflicts

### DIFF
--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -87,6 +87,9 @@ jobs:
             --baseURL "${{ steps.base_url.outputs.base_url }}/" \
             --destination "public/pr-${{ github.event.number }}"
 
+      - name: List files in workspace for debugging
+        run: ls -R
+
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
         with:

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -61,7 +61,7 @@ jobs:
             --source base \
             --minify \
             --baseURL "${{ steps.pages.outputs.base_url }}/" \
-            --destination "public"
+            --destination "${{ github.workspace }}/public"
 
       # Build PR preview
       - name: Checkout PR branch
@@ -85,10 +85,7 @@ jobs:
             --source pr \
             --minify \
             --baseURL "${{ steps.base_url.outputs.base_url }}/" \
-            --destination "public/pr-${{ github.event.number }}"
-
-      - name: List files in workspace for debugging
-        run: ls -R
+            --destination "${{ github.workspace }}/public/pr-${{ github.event.number }}"
 
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -68,18 +68,21 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.sha }}
+          path: pr
           submodules: recursive
       - name: Install Node.js dependencies for PR
+        working-directory: pr
         run: "[[ -f package-lock.json || -f npm-shrinkwrap.json ]] && npm ci || true"
       - name: Set preview baseURL
         id: base_url
-        run: echo "base_url=${{ steps.pages.outputs.base_url }}${{ steps.pages.outputs.base_path }}/pr-${{ github.event.number }}" >> $GITHUB_OUTPUT
+        run: echo "base_url=${{ steps.pages.outputs.base_url }}/pr-${{ github.event.number }}" >> $GITHUB_OUTPUT
       - name: Build PR preview
         env:
           HUGO_ENVIRONMENT: production
           HUGO_ENV: production
         run: |
           hugo \
+            --source pr \
             --minify \
             --baseURL "${{ steps.base_url.outputs.base_url }}/" \
             --destination "public/pr-${{ github.event.number }}"
@@ -110,5 +113,5 @@ jobs:
         uses: peter-evans/create-or-update-comment@v4
         with:
           issue-number: ${{ github.event.pull_request.number }}
-          body: |
+          body: | # This is a multiline string, so newlines are preserved correctly.
             Preview deployed at: ${{ needs.build.outputs.preview_url }}

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -38,21 +38,44 @@ jobs:
           && sudo dpkg -i ${{ runner.temp }}/hugo.deb
       - name: Install Dart Sass Embedded
         run: sudo snap install dart-sass-embedded
-      - name: Checkout
-        uses: actions/checkout@v4
-        with:
-          submodules: recursive
       - name: Setup Pages
         id: pages
         uses: actions/configure-pages@v5
-      - name: Install Node.js dependencies
+
+      # Build production site from base branch
+      - name: Checkout base branch
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.base_ref }}
+          path: base
+          submodules: recursive
+      - name: Install Node.js dependencies for base
+        working-directory: base
+        run: "[[ -f package-lock.json || -f npm-shrinkwrap.json ]] && npm ci || true"
+      - name: Build production site
+        env:
+          HUGO_ENVIRONMENT: production
+          HUGO_ENV: production
+        run: |
+          hugo \
+            --source base \
+            --minify \
+            --baseURL "${{ steps.pages.outputs.base_url }}/" \
+            --destination "public"
+
+      # Build PR preview
+      - name: Checkout PR branch
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          submodules: recursive
+      - name: Install Node.js dependencies for PR
         run: "[[ -f package-lock.json || -f npm-shrinkwrap.json ]] && npm ci || true"
       - name: Set preview baseURL
         id: base_url
-        run: echo "base_url=https://yqtian.com/${{ github.event.repository.name }}/pr-${{ github.event.number }}" >> $GITHUB_OUTPUT
-      - name: Build with Hugo
+        run: echo "base_url=${{ steps.pages.outputs.base_url }}${{ steps.pages.outputs.base_path }}/pr-${{ github.event.number }}" >> $GITHUB_OUTPUT
+      - name: Build PR preview
         env:
-          # For maximum backward compatibility with Hugo modules
           HUGO_ENVIRONMENT: production
           HUGO_ENV: production
         run: |
@@ -60,6 +83,7 @@ jobs:
             --minify \
             --baseURL "${{ steps.base_url.outputs.base_url }}/" \
             --destination "public/pr-${{ github.event.number }}"
+
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
         with:

--- a/README.md
+++ b/README.md
@@ -3,10 +3,58 @@
 
 [![Deploy to Production](https://github.com/acmsigsoft/acmsigsoft.github.io/actions/workflows/production-deploy.yml/badge.svg)](https://github.com/acmsigsoft/acmsigsoft.github.io/actions/workflows/production-deploy.yml)
 
-## Info
-This repository contains the source code for the [ACM SIGSOFT website](https://www2.sigsoft.org). The website is built using Jekyll and hosted on GitHub Pages.
+## Overview
+Welcome to the ACM SIGSOFT GitHub repository!
+
+This repository contains the source code for the [ACM SIGSOFT website](https://www2.sigsoft.org). 
+The website is built using [Hugo-Universal-Theme](https://github.com/devcows/hugo-universal-theme) and hosted on GitHub Pages.
+
+
 The website is maintained by the [ACM SIGSOFT Information Director](https://www2.sigsoft.org/contact/).
+If you have any questions or suggestions, please feel free to contact the Information Director.
 
 ## Contributing
 If you would like to contribute to the website, please fork the repository and submit a pull request.
 We welcome contributions from anyone who is interested in improving the website.
+
+Most of the content on the website can be revised by modifying the Markdown files in the `content` directory.
+Images and other static files can be added to the `static` directory.
+Configuration of the website, including the top bar and index page, can be done in the `config.toml` file.
+
+### Development
+To editing the information on the website, you may fork this website repository and edit the content files in the `content` directory.
+Alternatively, you can also edit the content files directly on GitHub using the web interface.
+The content files are written in Markdown, and you can use any text editor to edit them.
+The website uses [Hugo](https://gohugo.io/) as the static site generator, so you will need to install Hugo to build the website locally.
+You can find the documentation for Hugo [here](https://gohugo.io/documentation/).
+
+
+
+### Testing
+To test the website locally, please clone this repository and run the following commands:
+
+```bash
+# Clone the repository and its submodules
+# you may have to change the URL to your forked repository
+git clone --recurse-submodules git@github.com:acmsigsoft/acmsigsoft.github.io.git
+
+# Install Hugo if you haven't already
+# See https://gohugo.io/installation/
+brew install hugo # For macOS users
+sudo snap install hugo # For linux users
+
+# Navigate to the repository directory
+cd acmsigsoft.github.io
+
+# Start the Hugo server
+hugo server
+```
+
+Alternatively, to test the website on GitHub, please create a pull request and the GitHub Actions workflow will automatically build and deploy the website to a staging environment.
+You can then review the changes on the staging environment before asking for reviewing the pull request.
+
+There are two GitHub Actions workflows defined in the `.github/workflows` directory:
+- `pr-preview.yml`: This workflow is triggered on pull requests and deploys the website to a temporary URL.
+- `production-deploy.yml`: This workflow is triggered on pushes to the main branch and deploys the website to the production URL.
+You can enable these workflows in your forked repository by going to the "Actions" tab and clicking on the "Enable workflow" button. 
+

--- a/README.md
+++ b/README.md
@@ -1,4 +1,12 @@
-# acmsigsoft.github.io
-SIGSOFT Website
+# Website of The ACM Special Interest Group on Software Engineering (SIGSOFT)
 
-[![Deploy Hugo site to Pages](https://github.com/acmsigsoft/acmsigsoft.github.io/actions/workflows/main.yml/badge.svg)](https://github.com/acmsigsoft/acmsigsoft.github.io/actions/workflows/main.yml)
+
+[![Deploy to Production](https://github.com/acmsigsoft/acmsigsoft.github.io/actions/workflows/production-deploy.yml/badge.svg)](https://github.com/acmsigsoft/acmsigsoft.github.io/actions/workflows/production-deploy.yml)
+
+## Info
+This repository contains the source code for the [ACM SIGSOFT website](https://www2.sigsoft.org). The website is built using Jekyll and hosted on GitHub Pages.
+The website is maintained by the [ACM SIGSOFT Information Director](https://www2.sigsoft.org/contact/).
+
+## Contributing
+If you would like to contribute to the website, please fork the repository and submit a pull request.
+We welcome contributions from anyone who is interested in improving the website.


### PR DESCRIPTION
- Update the README to include instructions for updating the website

The previous pull request preview workflow deployed directly to the
      GitHub Pages environment, completely overwriting the existing site
      content. This meant that generating a PR preview would take down the live
      production site.

This commit modifies the preview workflow to make it non-destructive:

- The workflow now first checks out the `main` branch and builds the full
production site into the `/public` directory.
- It then checks out the pull request's head branch and builds the 
specific PR preview into a subdirectory (e.g., `/public/pr-123`).
- The combined result is then deployed, ensuring that the production site
and the PR preview can coexist.