### PR TITLE
Document submodule init step for Docker workflow

### DIFF
--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -36,8 +36,14 @@ jobs:
         run: |
           wget -O ${{ runner.temp }}/hugo.deb https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_extended_${HUGO_VERSION}_linux-amd64.deb \
           && sudo dpkg -i ${{ runner.temp }}/hugo.deb
-      - name: Install Dart Sass Embedded
-        run: sudo snap install dart-sass-embedded
+      - name: Install Dart Sass
+        env:
+          DART_SASS_VERSION: 1.83.4
+        run: |
+          wget -O /tmp/dart-sass.tar.gz \
+            "https://github.com/sass/dart-sass/releases/download/${DART_SASS_VERSION}/dart-sass-${DART_SASS_VERSION}-linux-x64.tar.gz"
+          tar -xf /tmp/dart-sass.tar.gz -C /tmp
+          echo "/tmp/dart-sass" >> $GITHUB_PATH
       - name: Setup Pages
         id: pages
         uses: actions/configure-pages@v5

--- a/.github/workflows/production-deploy.yml
+++ b/.github/workflows/production-deploy.yml
@@ -36,8 +36,14 @@ jobs:
         run: |
           wget -O ${{ runner.temp }}/hugo.deb https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_extended_${HUGO_VERSION}_linux-amd64.deb \
           && sudo dpkg -i ${{ runner.temp }}/hugo.deb
-      - name: Install Dart Sass Embedded
-        run: sudo snap install dart-sass-embedded
+      - name: Install Dart Sass
+        env:
+          DART_SASS_VERSION: 1.83.4
+        run: |
+          wget -O /tmp/dart-sass.tar.gz \
+            "https://github.com/sass/dart-sass/releases/download/${DART_SASS_VERSION}/dart-sass-${DART_SASS_VERSION}-linux-x64.tar.gz"
+          tar -xf /tmp/dart-sass.tar.gz -C /tmp
+          echo "/tmp/dart-sass" >> $GITHUB_PATH
       - name: Checkout
         uses: actions/checkout@v4
         with:

--- a/README.md
+++ b/README.md
@@ -53,6 +53,10 @@ hugo server
 If you prefer not to install Hugo locally, you can also run the site with Docker using the same Hugo version as CI:
 
 ```bash
+# Make sure the theme submodule is checked out (otherwise only a few
+# pages will be rendered and most URLs will 404).
+git submodule update --init --recursive
+
 # Start a local preview at http://127.0.0.1:1313
 docker compose up
 


### PR DESCRIPTION
Without initializing the hugo-universal-theme submodule, the Docker build only produces a handful of pages and most URLs return 404.