### PR TITLE
Add Software Engineering Academy highlight

### DIFF
--- a/content/awards/sigsoftAwards.md
+++ b/content/awards/sigsoftAwards.md
@@ -22,10 +22,39 @@ criteria for each of the SIGSOFT awards.
 ## Award Categories
 
 ### Senior Awards
-- **[Software Engineering Academy](/academy/inaugural-class.html)** - Honors lasting contributions to software engineering, in research, practice, and education
+- **[Software Engineering Academy](../../academy/inaugural-class.html)** - Honors lasting contributions to software engineering, in research, practice, and education
 - **[Distinguished Service Award](/awards/distinguishedservice/)** - Recognizes dedicated and important service to the software engineering community 
 - **[Outstanding Research Award](/awards/outstandingresearch/)** - Honors significant and lasting research contributions to the theory or practice of software engineering
 - **[Influential Educator Award](/awards/influentialeducator/)** - Celebrates significant contributions and impact on software engineering education as a teacher, mentor, researcher, author, and/or policy maker
+
+### SIGSOFT Software Engineering Academy
+
+The Software Engineering Academy is a standing body of honor that recognizes
+members of the software engineering community whose significant and lasting
+contributions have shaped the field.
+
+Established by ACM SIGSOFT, the Software Engineering Academy celebrates the
+people whose cumulative work, and whose influence on the work of others, have
+advanced software engineering as a discipline and a practice.
+
+The Academy recognizes:
+
+1. **Lasting contributions**: Significant, cumulative advances to the theory or
+   practice of software engineering, sustained across a career.
+2. **Influence on the field**: Work that has demonstrably shaped the research,
+   tools, and thinking of others across the community.
+3. **Leadership and service**: Stewardship of the discipline through mentorship,
+   education, and service to the software engineering community.
+
+The founding class establishes the foundation the Academy will grow from. To
+seed the Academy, the inaugural members were drawn from those whose standing in
+the field is already firmly established: recognized leaders whose contributions
+the community has long acknowledged, ACM Fellows within the software engineering
+community, and past ACM SIGSOFT Outstanding Research Award recipients honored
+for research, service, and impact.
+
+Going forward, new members are elected annually by a selection committee from
+community nominations. View the [inaugural class](../../academy/inaugural-class.html).
 
 ### Junior Awards
 - **[Outstanding Doctoral Dissertation Award](https://www2.sigsoft.org/awards/dissertation/)** - Presented to the author of an outstanding doctoral dissertation in software engineering

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html lang="{{ .Site.LanguageCode }}">
+
+  <head>
+    {{ partial "headers.html" . }}
+    {{ partial "custom_headers.html" . }}
+  </head>
+
+  <body>
+
+    <div id="all">
+
+        {{ partial "top.html" . }}
+
+        {{ partial "nav.html" . }}
+
+        {{ partial "carousel.html" . }}
+
+        {{ partial "features.html" . }}
+
+        {{ partial "academy_highlight.html" . }}
+
+        {{ partial "testimonials.html" . }}
+
+        {{ partial "see_more.html" . }}
+
+        {{ partial "recent_posts.html" . }}
+
+        {{ partial "clients.html" . }}
+
+        {{ partial "footer.html" . }}
+
+    </div>
+    <!-- /#all -->
+
+    {{ partial "scripts.html" . }}
+
+  </body>
+</html>

--- a/layouts/partials/academy_highlight.html
+++ b/layouts/partials/academy_highlight.html
@@ -1,0 +1,26 @@
+<section class="bar background-white academy-highlight">
+  <div class="container">
+    <div class="row academy-highlight__row">
+      <div class="col-md-7">
+        <p class="academy-highlight__eyebrow">New Recognition Program</p>
+        <h2>Software Engineering Academy</h2>
+        <p class="lead">
+          Celebrating lasting contributions to software engineering in research, practice, and education.
+        </p>
+        <p>
+          <a href="{{ "/academy/inaugural-class.html" | relURL }}" class="btn btn-template-main">
+            View the Inaugural Class
+          </a>
+        </p>
+      </div>
+      <div class="col-md-5">
+        <a href="{{ "/academy/inaugural-class.html" | relURL }}" class="academy-highlight__photos" aria-label="View the Software Engineering Academy inaugural class">
+          <img src="{{ "/academy/academy-photos/mary-shaw.jpg" | relURL }}" alt="Mary Shaw">
+          <img src="{{ "/academy/academy-photos/david-harel.jpg" | relURL }}" alt="David Harel">
+          <img src="{{ "/academy/academy-photos/jeannette-m-wing.jpg" | relURL }}" alt="Jeannette M. Wing">
+          <img src="{{ "/academy/academy-photos/elaine-weyuker.jpg" | relURL }}" alt="Elaine Weyuker">
+        </a>
+      </div>
+    </div>
+  </div>
+</section>

--- a/static/css/custom.css
+++ b/static/css/custom.css
@@ -1,4 +1,58 @@
 /* your styles go here */
+
+.academy-highlight {
+  border-top: 1px solid #eeeeee;
+  border-bottom: 1px solid #eeeeee;
+}
+
+.academy-highlight__row {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+}
+
+.academy-highlight__eyebrow {
+  color: #467fbf;
+  font-size: 13px;
+  font-weight: 700;
+  letter-spacing: 0;
+  margin-bottom: 8px;
+  text-transform: uppercase;
+}
+
+.academy-highlight h2 {
+  font-size: 30px;
+  margin-top: 0;
+}
+
+.academy-highlight .lead {
+  margin-bottom: 24px;
+}
+
+.academy-highlight__photos {
+  display: grid;
+  gap: 10px;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+}
+
+.academy-highlight__photos img {
+  aspect-ratio: 1;
+  border: 1px solid #dddddd;
+  display: block;
+  height: auto;
+  object-fit: cover;
+  width: 100%;
+}
+
+@media (max-width: 991px) {
+  .academy-highlight__row {
+    display: block;
+  }
+
+  .academy-highlight__photos {
+    margin-top: 22px;
+  }
+}
 /* Example site test */
 
 .box-image-text .image {


### PR DESCRIPTION
Adds the Software Engineering Academy to the site experience: a homepage highlight, expanded Awards Overview copy, and links to the inaugural class page.